### PR TITLE
Normalizza iniziale maiuscola nei campi testuali IVG 2026

### DIFF
--- a/maidati_ivg_2026/data/ivg_numeri.csv
+++ b/maidati_ivg_2026/data/ivg_numeri.csv
@@ -14,9 +14,9 @@ Friuli-Venezia Giulia,Regione,06,,2024,358,926,,,
 Lazio,Regione,12,,2023,2697,7574,,,Farmacologiche 2023: 3.843 ospedaliero + 3.731 territoriale
 Lazio,Regione,12,,2024,2472,6924,,,Farmacologiche 2024: 3.925 ospedaliero + 2.999 territoriale
 Lazio,Regione,12,,2025,2165,3855,,,Dati provvisori; farmacologiche 2025 solo ospedaliero
-Liguria,Regione,07,,2023,114,344,,41,dati parziali: risposta relativa a una sola struttura
-Liguria,Regione,07,,2024,208,449,,146,dati parziali: risposta relativa a una sola struttura
-Liguria,Regione,07,,2025,189,457,,126,dati parziali: risposta relativa a una sola struttura
+Liguria,Regione,07,,2023,114,344,,41,Dati parziali: risposta relativa a una sola struttura
+Liguria,Regione,07,,2024,208,449,,146,Dati parziali: risposta relativa a una sola struttura
+Liguria,Regione,07,,2025,189,457,,126,Dati parziali: risposta relativa a una sola struttura
 Lombardia,Regione,03,,2023,5870,5507,,,
 Lombardia,Regione,03,,2024,5156,6264,,,
 Lombardia,Regione,03,,2025,4548,6740,,,
@@ -25,20 +25,20 @@ Marche,Regione,11,,2024,691,490,,21,
 Molise,Regione,14,,2023,44,215,,,
 Molise,Regione,14,,2024,29,228,,,
 Molise,Regione,14,,2025,28,251,,,
-Piemonte,Regione,01,,2023,,,,,i dati relativi all’annualità 2023 non risultano ancora validati dal Ministero della Salute
-Piemonte,Regione,01,,2024,,,,,"i dati relativi all’annualità 2024 risultano, ad oggi, in fase di controllo e verifica finale"
-Piemonte,Regione,01,,2025,,,,,i dati relativi all’annualità 2025 risultano in corso di lavorazione
-Provincia Autonoma di Bolzano/Bozen,Provincia autonoma,04,021,2023,,,547,,dati non divisi tra chirurgiche e non
-Provincia Autonoma di Bolzano/Bozen,Provincia autonoma,04,021,2024,,,521,,dati non divisi tra chirurgiche e non
-Provincia Autonoma di Bolzano/Bozen,Provincia autonoma,04,021,2025,,,587,,dati non divisi tra chirurgiche e non
+Piemonte,Regione,01,,2023,,,,,I dati relativi all’annualità 2023 non risultano ancora validati dal Ministero della Salute
+Piemonte,Regione,01,,2024,,,,,"I dati relativi all’annualità 2024 risultano, ad oggi, in fase di controllo e verifica finale"
+Piemonte,Regione,01,,2025,,,,,I dati relativi all’annualità 2025 risultano in corso di lavorazione
+Provincia Autonoma di Bolzano/Bozen,Provincia autonoma,04,021,2023,,,547,,Dati non divisi tra chirurgiche e non
+Provincia Autonoma di Bolzano/Bozen,Provincia autonoma,04,021,2024,,,521,,Dati non divisi tra chirurgiche e non
+Provincia Autonoma di Bolzano/Bozen,Provincia autonoma,04,021,2025,,,587,,Dati non divisi tra chirurgiche e non
 Puglia,Regione,16,,2023,2190,3138,,30,
 Puglia,Regione,16,,2024,1806,3149,,16,
 Puglia,Regione,16,,2025,1655,3282,,26,
 Sardegna,Regione,20,,2023,663,694,,,
 Sardegna,Regione,20,,2024,463,967,,,
 Sardegna,Regione,20,,2025,360,899,,,
-Sicilia,Regione,19,,2023,2306,1927,,85,per 15 casi il metodo non è stato rilevato (N.R.)
-Sicilia,Regione,19,,2024,2049,2380,,41,per 30 casi il metodo non è stato rilevato (N.R.)
+Sicilia,Regione,19,,2023,2306,1927,,85,Per 15 casi il metodo non è stato rilevato (N.R.)
+Sicilia,Regione,19,,2024,2049,2380,,41,Per 30 casi il metodo non è stato rilevato (N.R.)
 Toscana,Regione,09,,2023,1620,2821,,,
 Toscana,Regione,09,,2024,1483,2878,,,
 Umbria,Regione,10,,2023,257,693,,12,
@@ -48,4 +48,4 @@ Valle d'Aosta/Vallée d'Aoste,Regione,02,,2023,42,91,,,
 Valle d'Aosta/Vallée d'Aoste,Regione,02,,2024,40,81,,,
 Veneto,Regione,05,,2023,1985,2282,,,
 Veneto,Regione,05,,2024,1590,2619,,,
-Veneto,Regione,05,,2025,715,1367,,,dati primo semestre
+Veneto,Regione,05,,2025,715,1367,,,Dati primo semestre

--- a/maidati_ivg_2026/data/ivg_qualitativo.csv
+++ b/maidati_ivg_2026/data/ivg_qualitativo.csv
@@ -1,28 +1,28 @@
 nome,tipo,cod_reg,cod_uts,costo_chirurgica,costo_farmacologica,tipo_ricovero_chirurgica,tipo_ricovero_farmacologica,ambulatoriali,motivo_mai_dati
 Valle d'Aosta/Vallée d'Aoste,Regione,02,,"Non sono previsti rimborsi per le procedure relative all’IVG in quanto non vi sono
-costi a carico dell’utente.",Non sono previsti rimborsi per le procedure relative all’IVG in quanto non vi sono costi a carico dell’utente.,Ordinario o Day hospital,Ordinario o Day hospital,no,
-Friuli-Venezia Giulia,Regione,06,,,Il rimborso per le procedure è quello previsto dal regime di ricovero in Day Hospital.,Day hospital,Day hospital,no,
-Emilia-Romagna,Regione,08,,risposta non pertinente,risposta non pertinente,Day surgery,ambulatoriale,sì domiciliari,
-Provincia Autonoma di Bolzano/Bozen,Provincia autonoma,04,021,risposta non pertinente,risposta non pertinente,Day surgery,ambulatoriale,Bolzano domicilio,
+costi a carico dell’utente.",Non sono previsti rimborsi per le procedure relative all’IVG in quanto non vi sono costi a carico dell’utente.,Ordinario o Day hospital,Ordinario o Day hospital,No,
+Friuli-Venezia Giulia,Regione,06,,,Il rimborso per le procedure è quello previsto dal regime di ricovero in Day Hospital.,Day hospital,Day hospital,No,
+Emilia-Romagna,Regione,08,,Risposta non pertinente,Risposta non pertinente,Day surgery,Ambulatoriale,Sì domiciliari,
+Provincia Autonoma di Bolzano/Bozen,Provincia autonoma,04,021,Risposta non pertinente,Risposta non pertinente,Day surgery,Ambulatoriale,Bolzano domicilio,
 Provincia Autonoma di Trento,Provincia autonoma,04,022,,,,,,
 Calabria,Regione,18,,,,,,,"L’evasione dell’istanza presuppone, tuttavia, l’acquisizione di dati da parte delle strutture sanitarie competenti, dislocate territorialmente nell’ambito dell’intera area regionale, per i quali si è provveduto a inoltrare apposita richiesta."
 Basilicata,Regione,17,,Non sono previste forme di rimborso,Non sono previste forme di rimborso,Day surgery,Day surgery,Vengono eseguite le IVG ambulatoriali (in regime di DH terapeutico),
 Sicilia,Regione,19,,Non sono previste forme di rimborso,Non sono previste forme di rimborso,Ordinario o Day hospital,Ordinario o Day hospital,,
-Campania,Regione,15,,"la Regione Campania sta attualmente lavorando alla definizione degli aspetti correlati ai
-rimborsi e ai regimi assistenziali per le procedure di IVG.","la Regione Campania sta attualmente lavorando alla definizione degli aspetti correlati ai
+Campania,Regione,15,,"La Regione Campania sta attualmente lavorando alla definizione degli aspetti correlati ai
+rimborsi e ai regimi assistenziali per le procedure di IVG.","La Regione Campania sta attualmente lavorando alla definizione degli aspetti correlati ai
 rimborsi e ai regimi assistenziali per le procedure di IVG.",Day surgery,Day surgery,Sì. La possibilità di autosomministrazione a domicilio è prevista e disciplinata dal protocollo regionale ,
-Toscana,Regione,09,,"€ 1.099,00","€ 500,00",Day hospital o ricovero ordinario,"nella maggior parte dei casi in regime ambulatoriale ma possono essere svolte anche in regime
+Toscana,Regione,09,,"€ 1.099,00","€ 500,00",Day hospital o ricovero ordinario,"Nella maggior parte dei casi in regime ambulatoriale ma possono essere svolte anche in regime
 ospedaliero (per lo più day hospital)",,
-Liguria,Regione,07,,1.133 (ordinario); 209 (diurno); con dilatazione e raschiamento 989 (ordinario); 1099 (diurno),mai dati,Day hospital,Day hospital (a parte le ambulatoriali),,
-Lombardia,Regione,03,,"€ 952,00","€ 1.246,00",Day hospital,Day hospital,no,
-Molise,Regione,14,,risposta non pertinente,risposta non pertinente,Day hospital,Day hospital,ci stanno lavorando,
-Sardegna,Regione,20,,"346,54 dilatazione e rasc; isterotomia 1011,73",mai dati,Ordinario,Ordinario,no,
-Piemonte,Regione,01,,"La IVG è un diritto riconosciuto dalla legge in Italia e, per le cittadine iscritte al Servizio",,Day surgery,Day hospital o Day surgery,no,
+Liguria,Regione,07,,1.133 (ordinario); 209 (diurno); con dilatazione e raschiamento 989 (ordinario); 1099 (diurno),Mai dati,Day hospital,Day hospital (a parte le ambulatoriali),,
+Lombardia,Regione,03,,"€ 952,00","€ 1.246,00",Day hospital,Day hospital,No,
+Molise,Regione,14,,Risposta non pertinente,Risposta non pertinente,Day hospital,Day hospital,Ci stanno lavorando,
+Sardegna,Regione,20,,"346,54 dilatazione e rasc; isterotomia 1011,73",Mai dati,Ordinario,Ordinario,No,
+Piemonte,Regione,01,,"La IVG è un diritto riconosciuto dalla legge in Italia e, per le cittadine iscritte al Servizio",,Day surgery,Day hospital o Day surgery,No,
 Abruzzo,Regione,13,,"€ 1.099,00","€ 209,00",Day hospital,Day hospital,Nella Regione Abruzzo attualmente non ci sono Consultori che effettuano l'IVG farmacologica ambulatoriale. Si effettua in setting ambulatoriale solo presso il Centro Erogazione Servizi (CERS) Pescara Sud di Via Sparto.,
-Marche,Regione,11,,risposta non pertinente,risposta non pertinente,Ordinario,Ordinario,no,
-Puglia,Regione,16,,Per quanto attiene i rimborsi previsti si fa riferimento al nomenclatore tariffario ed alla normativa nazionale,Per quanto attiene i rimborsi previsti si fa riferimento al nomenclatore tariffario ed alla normativa nazionale,Ordinario (rari casi) o Day hospital,Ordinario (rari casi) o Day hospital,no,
+Marche,Regione,11,,Risposta non pertinente,Risposta non pertinente,Ordinario,Ordinario,No,
+Puglia,Regione,16,,Per quanto attiene i rimborsi previsti si fa riferimento al nomenclatore tariffario ed alla normativa nazionale,Per quanto attiene i rimborsi previsti si fa riferimento al nomenclatore tariffario ed alla normativa nazionale,Ordinario (rari casi) o Day hospital,Ordinario (rari casi) o Day hospital,No,
 Umbria,Regione,10,,"In merito alla richiesta relativa ai rimborsi previsti per le varie procedure e regimi assistenziali, si
 informa che questa Amministrazione non dispone di tali dati e informazioni nei propri archivi.","In merito alla richiesta relativa ai rimborsi previsti per le varie procedure e regimi assistenziali, si
 informa che questa Amministrazione non dispone di tali dati e informazioni nei propri archivi.",Day hospital o ordinario,Day hospital o ordinario,"Sebbene non ci sia un legame esplicito nelle tabelle, i dati sul ""Luogo dell'intervento"" indicano che una piccola parte degli interventi (specialmente nel 2023 e 2025) è avvenuta in ambulatori pubblici o consultori (rispettivamente 52 casi nel 2023 e 22 nel 2025), contesti solitamente legati alla procedura farmacologica",
-Veneto,Regione,05,,tariffe nazionali e regionali,tariffe nazionali e regionali,Day hospital,Day hospital,no,
+Veneto,Regione,05,,Tariffe nazionali e regionali,Tariffe nazionali e regionali,Day hospital,Day hospital,No,
 Lazio,Regione,12,,,,,,,


### PR DESCRIPTION
Uniforma a **iniziale maiuscola** i campi descrittivi dei due CSV in `maidati_ivg_2026/data/`:

- `ivg_numeri.csv` → campo `note` (12 celle)
- `ivg_qualitativo.csv` → `costo_*`, `tipo_ricovero_*`, `ambulatoriali`, `motivo_mai_dati` (27 celle)

## Motivazione
Confrontando i CSV pubblicati con il Google Sheet sorgente, l'unica differenza era la **capitalizzazione dell'iniziale** dei campi testuali (lowercase introdotto in fase di pubblicazione). Lo Sheet stesso aveva inoltre incoerenze tra celle con testo identico (es. Campania `La/la Regione…`, Emilia/Molise `Risposta/risposta non pertinente`).

Questa PR normalizza **tutti** i valori testuali a iniziale maiuscola, eliminando sia l'artefatto sia le incoerenze.

## Note
- Nessun valore numerico modificato; nessuna riga aggiunta/rimossa.
- I valori che iniziano con simbolo o cifra (importi tipo `€ 1.099,00`, `346,54 …`) restano invariati.
- `mai dati` → `Mai dati` (Liguria, Sardegna).